### PR TITLE
Changes to match object and string interfaces

### DIFF
--- a/array.h
+++ b/array.h
@@ -3,6 +3,7 @@
 #include "object.h"
 
 // Representation of an array: expands as necessary
+// authors: lee.seu@husky.neu.edu, aguilar.ca@husky.neu.edu
 class Array: public Object {
 public:
 	// default constructor for array

--- a/object.h
+++ b/object.h
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 
 // Representation of an object
+// authors: lee.seu@husky.neu.edu, aguilar.ca@husky.neu.edu
 class Object {
 public:
 
@@ -17,13 +18,21 @@ public:
 		return this == other;
 	}
 
+	/** Returns the object's hash value. Two objects that are equal should         
+   	* have the same hash; object's that are not, may have the same hash.          
+   	* Subclasses should implement hash_me_(). */ 
+	size_t hash() {}
+
 	// unimplemented hash code function
-	virtual size_t hash() {
+	virtual size_t hash_me_() {
 		return 1;
 	}
 
 	// return string representation of this object
 	virtual char* to_string() {}
+
+	/** Print to stdout. */                                                        
+  	virtual void print() {} 
 
 	// returns a copy of this object
 	virtual Object* clone() {}

--- a/string.h
+++ b/string.h
@@ -3,19 +3,24 @@
 #include "object.h"
 
 // Representation of a string
+// Passed in values should be copied and deleted
+// authors: lee.seu@husky.neu.edu, aguilar.ca@husky.neu.edu
 class String: public Object {
 public:
 	// default constructor that inherits from Object
 	String() : Object() {}
 
-	// constructor to create String from a String literal
+	// constructor to create String copying c
+	String(char* c): Object() {}
+
+	// constructor to create String copying c
 	String(const char* c): Object() {}
 
 	// destructor
 	~String() {}
 
 	// returns length of the string
-	size_t length() {}
+	size_t size() {}
 
 	// returns result of concatenating this string and s
 	String* concat(String* s) {}
@@ -27,7 +32,7 @@ public:
 	// returns a number < 0 if this string comes lexicographically before the given string
 	// returns 0 if this string is lexicographically equal to the given string
 	// returns a number > 0 if this string comes lexicographically after the given string
-	int compare_to(String* s) {}
+	int compare(String* s) {}
 
 	// checks if the given object is equal to this String
 	bool equals(Object * other) {
@@ -35,13 +40,17 @@ public:
 	}
 
 	// unimplemented hash code function
-	size_t hash() {}
+	size_t hash_me_() {}
 
 	// return string representation of this object
+	// should not return a reference to any internal objects
 	char* to_string() {}
 
 	// returns a copy of this object
 	Object* clone() {
 		// STUB
 	}
+
+	// prints this string to stdout
+	void print() {}
 };

--- a/test-array.cpp
+++ b/test-array.cpp
@@ -3,6 +3,8 @@
 #include "string.h"
 #include "array.h"
 
+// authors: lee.seu@husky.neu.edu, aguilar.ca@husky.neu.edu
+
 void t_true(bool p) { if (!p) exit(1); }
 void t_false(bool p) { if (p) exit(1); }
 


### PR DESCRIPTION
Changes were made to match the Object and String interfaces found on [Piazza](https://piazza.com/class/k51bluky59n2jr?cid=166).

This was done at the request of issue #4.

The clone() methods on Object and String which were not present on the link were kept in the specs since they are methods we believe belong on these types.